### PR TITLE
fix(flow): avoid std::thread::spawn WASM trap; expose D8 pointer from flow_accum_full_workflow

### DIFF
--- a/crates/wbtools_oss/src/tools/flow_algorithms/mod.rs
+++ b/crates/wbtools_oss/src/tools/flow_algorithms/mod.rs
@@ -346,7 +346,7 @@ fn d8_dir_from_dem(input: &Raster) -> Vec<i8> {
     for tid in 0..num_procs {
         let view = view.clone();
         let tx = tx.clone();
-        thread::spawn(move || {
+        super::dispatch_worker(num_procs > 1, move || {
             for r in (0..rows).filter(|row| row % num_procs == tid) {
                 let mut row_data = vec![-2i8; cols];
                 for c in 0..cols {
@@ -803,7 +803,7 @@ fn fd8_pointer_from_dem(input: &Raster) -> Vec<f64> {
     for tid in 0..num_procs {
         let view = view.clone();
         let tx = tx.clone();
-        thread::spawn(move || {
+        super::dispatch_worker(num_procs > 1, move || {
             for r in (0..rows).filter(|row| row % num_procs == tid) {
                 let mut row_out = vec![OUT_NODATA; cols];
                 for c in 0..cols {
@@ -851,7 +851,7 @@ fn fd8_inflow_count(input: &Raster) -> Vec<i8> {
     for tid in 0..num_procs {
         let view = view.clone();
         let tx = tx.clone();
-        thread::spawn(move || {
+        super::dispatch_worker(num_procs > 1, move || {
             for r in (0..rows).filter(|row| row % num_procs == tid) {
                 let mut row_inflow = vec![-1i8; cols];
                 for c in 0..cols {
@@ -1319,7 +1319,7 @@ fn minimal_dispersion_core(
             let out_vals = out_vals;
             let y_max_val = y_max_val;
             let x_min_val = x_min_val;
-            thread::spawn(move || {
+            super::dispatch_worker(num_procs > 1, move || {
                 for r in (0..rows).filter(|row| row % num_procs == tid) {
                     let mut row_ptr = vec![0u16; cols];
                     let mut row_has_pit = false;
@@ -2072,7 +2072,7 @@ fn mdfa_initial_dirs_projected(input: &Raster, esri_style: bool) -> (Vec<u16>, V
         let tx = tx.clone();
         let out_vals = out_vals;
         let d8_lens = d8_lens;
-        thread::spawn(move || {
+        super::dispatch_worker(num_procs > 1, move || {
             for r in (0..rows).filter(|row| row % num_procs == tid) {
                 let mut row_d8 = vec![0u16; cols];
                 let mut row_dinf = vec![nodata; cols];
@@ -2204,7 +2204,7 @@ fn rho8_dir_from_dem(input: &Raster) -> Vec<i8> {
     for tid in 0..num_procs {
         let view = view.clone();
         let tx = tx.clone();
-        thread::spawn(move || {
+        super::dispatch_worker(num_procs > 1, move || {
             // Each thread gets its own RNG — rand::rng() is thread-local in rand 0.10.
             let mut rng = rand::rng();
             for r in (0..rows).filter(|row| row % num_procs == tid) {
@@ -2337,7 +2337,7 @@ fn d8_flow_accum_core(flow_dir: &[i8], rows: usize, cols: usize, nodata: f64) ->
     for tid in 0..num_procs {
         let fd = fd.clone();
         let tx = tx.clone();
-        thread::spawn(move || {
+        super::dispatch_worker(num_procs > 1, move || {
             for r in (0..rows).filter(|row| row % num_procs == tid) {
                 let mut row_inflow = vec![-1i8; cols];
                 for c in 0..cols {

--- a/crates/wbtools_oss/src/tools/hydrology/mod.rs
+++ b/crates/wbtools_oss/src/tools/hydrology/mod.rs
@@ -105,6 +105,7 @@ pub fn hydrology_tool_param_schemas(tool_id: &str) -> Option<BTreeMap<String, To
 			("esri_pntr", ToolParamSchema::bool()),
 			("breached_dem_output", ToolParamSchema::output_raster()),
 			("flow_dir_output", ToolParamSchema::output_raster()),
+			("output_pointer", ToolParamSchema::output_raster()),
 			("output", ToolParamSchema::output_raster()),
 		])),
 		"watershed" => Some(param_schema_map(&[
@@ -1972,7 +1973,7 @@ fn d8_dir_from_dem_local(input: &Raster) -> Vec<i8> {
 	for tid in 0..num_procs {
 		let view = view.clone();
 		let tx = tx.clone();
-		thread::spawn(move || {
+		super::dispatch_worker(num_procs > 1, move || {
 			for r in (0..rows).filter(|row| row % num_procs == tid) {
 				let mut row_dirs = vec![-2i8; cols];
 				for c in 0..cols {
@@ -2202,7 +2203,7 @@ fn build_flow_dir_and_mark_nodata(
 	for tid in 0..num_procs {
 		let view = view.clone();
 		let tx = tx.clone();
-		thread::spawn(move || {
+		super::dispatch_worker(num_procs > 1, move || {
 			for r in (0..rows).filter(|row| row % num_procs == tid) {
 				let mut row_flow = vec![-2i8; cols];
 				let mut row_nodata = vec![0u8; cols];
@@ -3748,6 +3749,11 @@ impl Tool for FlowAccumFullWorkflowTool {
 					required: false,
 				},
 				ToolParamSpec {
+					name: "output_pointer",
+					description: "Optional output path for the D8 flow-direction pointer (alias of flow_dir_output; ESRI-encoded when esri_pntr is set)",
+					required: false,
+				},
+				ToolParamSpec {
 					name: "output",
 					description: "Optional output path for flow-accumulation raster",
 					required: false,
@@ -3792,7 +3798,12 @@ impl Tool for FlowAccumFullWorkflowTool {
 			.or_else(|_| parse_raster_path_arg(args, "input"))
 			.or_else(|_| parse_raster_path_arg(args, "input_dem"))?;
 		let breached_dem_output = parse_optional_output_path(args, "breached_dem_output")?;
-		let flow_dir_output = parse_optional_output_path(args, "flow_dir_output")?;
+		// `output_pointer` is the public alias requested by consumers; fall back
+		// to the original `flow_dir_output` name for backwards compatibility.
+		let flow_dir_output = match parse_optional_output_path(args, "output_pointer")? {
+			Some(path) => Some(path),
+			None => parse_optional_output_path(args, "flow_dir_output")?,
+		};
 		let flow_accum_output = parse_optional_output_path(args, "output")?;
 
 		let out_type = args
@@ -4767,7 +4778,7 @@ impl Tool for D8MassFluxTool {
 				let dirs = dirs.clone();
 				let view = Arc::new(dem.band_view(0));
 				let tx = tx.clone();
-				thread::spawn(move || {
+				super::dispatch_worker(num_procs > 1, move || {
 					const INFLOWING: [i8; 8] = [4, 5, 6, 7, 0, 1, 2, 3];
 					for r in (0..rows).filter(|row| row % num_procs == tid) {
 						let mut row_inflow = vec![-1i32; cols];
@@ -10055,7 +10066,7 @@ fn stream_link_id_pass(pntr: &Raster, streams: &Raster, esri_style: bool, out_no
 		let pntr_view = pntr_view.clone();
 		let streams_view = streams_view.clone();
 		let tx = tx.clone();
-		thread::spawn(move || {
+		super::dispatch_worker(num_procs > 1, move || {
 			for r in (0..rows).filter(|row| row % num_procs == tid) {
 				let mut row_pourpts = vec![out_nodata; cols];
 				let mut row_inflow = vec![-1i8; cols];

--- a/crates/wbtools_oss/src/tools/mod.rs
+++ b/crates/wbtools_oss/src/tools/mod.rs
@@ -2,6 +2,35 @@ use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use wbcore::ToolParamSchema;
 
+/// Runs `work` on a background thread on native targets, or inline on the
+/// current thread when `parallel` is `false` or when compiling for wasm32.
+///
+/// `std::thread::spawn` is unsupported on `wasm32-unknown-unknown`: calling it
+/// at runtime traps with `unreachable`, which is why the threaded flow-routing
+/// helpers (D8 pointer, D8/FD8 accumulation, basins, ...) crashed in the
+/// browser/WASI runtime while the fully-serial composite workflow kept working.
+/// Routing every worker fan-out through this helper keeps the multi-threaded
+/// fast path on native CLI builds while degrading to a serial loop on wasm.
+///
+/// Callers use the established `mpsc` fan-out pattern (each worker sends its
+/// rows down a channel that the caller drains), so running inline is safe: the
+/// channel is unbounded and the inline closure finishes sending before the
+/// caller starts receiving.
+pub(crate) fn dispatch_worker<F>(parallel: bool, work: F)
+where
+	F: FnOnce() + Send + 'static,
+{
+	#[cfg(not(target_arch = "wasm32"))]
+	{
+		if parallel {
+			std::thread::spawn(work);
+			return;
+		}
+	}
+	let _ = parallel;
+	work();
+}
+
 mod raster;
 mod data_tools;
 mod gis;


### PR DESCRIPTION
## Problem

Standalone D8/FD8 flow-routing tools (`d8_pointer`, `d8_flow_accum`, `fd8_flow_accum`, `basins`, `subbasins`, ...) trap with a WASM `unreachable` instruction on **every** input DEM, while the composite `flow_accum_full_workflow` works fine. Reported downstream in opengeos/geolibre-rust#28.

### Root cause

These tools fan work out across rows with `std::thread::spawn`, which is **unsupported on the wasm32 targets GeoLibre ships** (`wasm32-wasip1` for the Python wheel / WASI runner, and `wasm32-unknown-unknown` for the browser library). At runtime the spawn fails:

```
thread 'main' panicked: failed to spawn thread: Os { code: 58, kind: Unsupported, message: "Not supported" }
...
wasm trap: wasm `unreachable` instruction executed
```

Because the runner is built with `panic = "abort"`, that panic becomes the `unreachable` trap users saw. The composite workflow was unaffected because it is fully serial.

## Fix

- Add a `dispatch_worker(parallel, work)` helper in `tools/mod.rs`. On native targets it spawns a thread (when more than one worker is requested); on wasm32 the `thread::spawn` branch is `#[cfg]`-compiled out and the closure runs **inline**. The existing `mpsc` fan-out/collect pattern is preserved, so native multi-threaded performance is unchanged and wasm degrades to a serial loop.
- Route all 11 `thread::spawn` fan-out sites in `flow_algorithms` (7) and `hydrology` (4) through it.
- **#29:** expose the D8 pointer the composite already computes via a new `output_pointer` argument (alias of the existing `flow_dir_output`), so accumulation and pointer come from the **same** internal breach pass. Pointer is ESRI-encodable with `--esri_pntr`.

## Verification

Built `geolibre-cli` for `wasm32-wasip1` and ran each tool through `wasmtime` on the issue's synthetic DEM:

| tool | before | after |
|------|--------|-------|
| `d8_pointer` | `unreachable` trap (exit 134) | ✅ exit 0, valid D8 codes |
| `d8_flow_accum` | `unreachable` trap | ✅ exit 0 |
| `fd8_flow_accum` | `unreachable` trap | ✅ exit 0 |
| `basins` | `unreachable` trap | ✅ exit 0 |
| `subbasins` | trap | ✅ runs with d8_pntr+streams |
| `flow_accum_full_workflow --output_pointer=… --esri_pntr` | n/a | ✅ writes ESRI pointer + accum from one breach pass |

Output sanity-checked with rasterio (composite accumulation max == cell count draining to the single outlet; pointer values are valid direction codes).

Fixes opengeos/geolibre-rust#28
Fixes opengeos/geolibre-rust#29

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `output_pointer` option for flow accumulation workflows, with support for existing encoding settings.
  * Improved parallel processing behavior in several hydrology workflows, helping tasks run more consistently across platforms.

* **Bug Fixes**
  * Preserved backward compatibility by continuing to accept the previous flow-direction output option.
  * Ensured processing falls back safely when background threading isn’t available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->