### PR TITLE
fix(wbcore): infer expression/statement params as free-text strings

### DIFF
--- a/crates/wbcore/src/lib.rs
+++ b/crates/wbcore/src/lib.rs
@@ -595,6 +595,19 @@ fn has_word(haystack: &str, word: &str) -> bool {
     false
 }
 
+/// Whether a parameter holds a free-text expression, statement, or formula that
+/// the user types (an attribute query, a field-calculator formula, a LiDAR
+/// filter clause). Matched on the parameter name, which is unambiguous here.
+///
+/// These must be caught before the flag and dataset heuristics: their
+/// descriptions routinely mention "boolean" (the value the expression evaluates
+/// to) or "feature"/"raster" (the data it runs against), which `looks_bool` and
+/// `infer_data_kind` would otherwise misread as a checkbox or a dataset input.
+fn looks_like_expression(name: &str) -> bool {
+    let n = name.to_ascii_lowercase();
+    has_word(&n, "expression") || has_word(&n, "statement")
+}
+
 /// Whether a parameter is a boolean flag, recognized from the conventional
 /// phrasings whitebox uses ("If true, …", "(default false)", "true/false").
 fn looks_bool(description: &str) -> bool {
@@ -786,6 +799,9 @@ fn infer_param_schema(name: &str, description: &str) -> ToolParamSchema {
         let kind = infer_data_kind(name, description, &ToolIoRole::Output);
         return schema_from_role_and_kind(Some(ToolIoRole::Output), kind)
             .unwrap_or(ToolParamSchema::String);
+    }
+    if looks_like_expression(name) {
+        return ToolParamSchema::String;
     }
     if looks_bool(description) {
         return ToolParamSchema::bool();
@@ -1638,6 +1654,39 @@ mod tests {
         assert!(matches!(schema_for("statement", "Conditional expression evaluated per cell."), ToolParamSchema::String));
         // No numeric noun at all.
         assert!(matches!(schema_for("note", "An arbitrary note."), ToolParamSchema::String));
+    }
+
+    #[test]
+    fn expression_params_stay_strings() {
+        // A free-text expression/statement is a string the user types, even when
+        // its description mentions "boolean" (the value it evaluates to) or
+        // "feature"/"raster" (the data it runs over), which would otherwise be
+        // read as a bool flag or a dataset input. Regression for GeoLibre #1073.
+        for (n, d) in [
+            // extract_by_attribute.statement -> was a bool checkbox ("Boolean …").
+            (
+                "statement",
+                "Boolean expression evaluated against attribute fields; accepts SQL-style AND/OR/NOT/XOR aliases.",
+            ),
+            // field_calculator.expression -> was a vector input ("… per feature").
+            (
+                "expression",
+                "Expression evaluated per feature. Supports SQL-style CASE, CAST(... AS type), IS NULL/IS NOT NULL.",
+            ),
+            // filter_lidar.statement -> was a bool checkbox.
+            (
+                "statement",
+                "Boolean expression, e.g. '!is_noise && class == 2' or 'NOT is_noise AND class == 2'.",
+            ),
+            // raster_calculator.expression -> was a raster input.
+            ("expression", "Math expression with quoted raster variable names."),
+        ] {
+            assert!(
+                matches!(schema_for(n, d), ToolParamSchema::String),
+                "{n}: {d:?} -> {:?}",
+                schema_for(n, d)
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Whitebox tools that take a user-typed expression render **no field to enter it**. Reported in GeoLibre [#1073](https://github.com/opengeos/GeoLibre/issues/1073):

- **Extract By Attribute** (`statement`) shows a checkbox instead of a text field.
- **Field Calculator** (`expression`) shows a duplicate vector-input picker instead of a text field.

The manifest inference in `infer_param_schema` reads these free-text params from their name + description. Their descriptions mention "boolean" (the value the expression evaluates *to*) or "feature"/"raster" (the data it runs *against*), so:

- `looks_bool` matches the word "boolean" and returns a bool flag, and
- `infer_data_kind` matches "feature"/"raster" and returns a dataset input.

Both are wrong: the parameter *is* the expression.

## Fix

A parameter named `expression` or `statement` holds free text the user types, so short-circuit it to a string schema before the bool/enum/dataset heuristics run.

Affected tools now infer `string` for these params: `extract_by_attribute.statement`, `field_calculator.expression`, `filter_lidar.statement`, `raster_calculator.expression`. `select_by_location.query` (a genuine query *layer*) is unaffected.

## Verification

- New regression test `expression_params_stay_strings` uses the real tool descriptions; `cargo test -p wbcore` passes (20 tests).
- Verified end to end by patching geolibre-rust to this local checkout and running `cargo run -p geolibre-cli -- manifests`: all four params now emit `string`, and `select_by_location.query` stays a dataset input.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic parameter type detection so fields that look like free-text expressions or statements are now treated as text inputs.
  * Prevented these parameters from being mistaken for booleans or dataset-style inputs based on description wording.
  * Added regression coverage to keep common “expression” and “statement” cases classified as text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->