### PR TITLE
fix(wbgeotiff): reverse TIFF horizontal/floating-point predictors on decode

### DIFF
--- a/crates/wbgeotiff/src/compression.rs
+++ b/crates/wbgeotiff/src/compression.rs
@@ -428,8 +428,8 @@ fn rows_present(buf_len: usize, rows: usize, row_bytes: usize) -> impl Iterator<
     (0..rows).map(move |r| (r * row_bytes, r * row_bytes + row_bytes)).take_while(move |&(_, end)| end <= buf_len)
 }
 
-/// Reverse horizontal differencing (Predictor 2) for 1-, 2-, or 4-byte integer
-/// samples.
+/// Reverse horizontal differencing (Predictor 2) for 1-, 2-, 4-, or 8-byte
+/// integer samples.
 fn undo_horizontal(buf: &mut [u8], cols: usize, rows: usize, spp: usize, bps: usize) -> Result<()> {
     let row_bytes = cols * spp * bps;
     if cols <= 1 || row_bytes == 0 {
@@ -458,6 +458,15 @@ fn undo_horizontal(buf: &mut [u8], cols: usize, rows: usize, spp: usize, bps: us
                     let prev = u32::from_le_bytes([row[p], row[p + 1], row[p + 2], row[p + 3]]);
                     let cur = u32::from_le_bytes([row[c], row[c + 1], row[c + 2], row[c + 3]]);
                     row[c..c + 4].copy_from_slice(&cur.wrapping_add(prev).to_le_bytes());
+                }
+            }
+            8 => {
+                for i in spp..samples {
+                    let p = (i - spp) * 8;
+                    let c = i * 8;
+                    let prev = u64::from_le_bytes(row[p..p + 8].try_into().unwrap());
+                    let cur = u64::from_le_bytes(row[c..c + 8].try_into().unwrap());
+                    row[c..c + 8].copy_from_slice(&cur.wrapping_add(prev).to_le_bytes());
                 }
             }
             other => {
@@ -560,6 +569,23 @@ mod predictor_tests {
             .map(|c| u16::from_le_bytes([c[0], c[1]]))
             .collect();
         assert_eq!(got, vec![1000, 1005, 1002]);
+    }
+
+    #[test]
+    fn horizontal_u64_little_endian() {
+        // 64-bit integer samples (reachable via read_band_u64/i64) must decode
+        // too. Original u64 row [5_000_000_000, 5_000_000_007, 5_000_000_004];
+        // diffs [5_000_000_000, 7, -3].
+        let mut buf = Vec::new();
+        for v in [5_000_000_000u64, 7, (-3i64 as u64)] {
+            buf.extend_from_slice(&v.to_le_bytes());
+        }
+        undo_predictor(&mut buf, PREDICTOR_HORIZONTAL, 3, 1, 1, 8).unwrap();
+        let got: Vec<u64> = buf
+            .chunks_exact(8)
+            .map(|c| u64::from_le_bytes(c.try_into().unwrap()))
+            .collect();
+        assert_eq!(got, vec![5_000_000_000, 5_000_000_007, 5_000_000_004]);
     }
 
     #[test]

--- a/crates/wbgeotiff/src/compression.rs
+++ b/crates/wbgeotiff/src/compression.rs
@@ -378,6 +378,226 @@ pub fn decompress(codec: Compression, input: &[u8], expected_len: usize) -> Resu
     }
 }
 
+// ── Predictor ──────────────────────────────────────────────────────────────────
+
+/// TIFF `Predictor` tag (317): samples are stored verbatim.
+pub const PREDICTOR_NONE: u16 = 1;
+/// TIFF `Predictor` tag (317): horizontal differencing (integer samples). Each
+/// sample stores its difference from the same channel of the previous pixel in
+/// the row.
+pub const PREDICTOR_HORIZONTAL: u16 = 2;
+/// TIFF `Predictor` tag (317): floating-point predictor (byte-plane horizontal
+/// differencing, per the TIFF Technical Note 3 / libtiff).
+pub const PREDICTOR_FLOATING_POINT: u16 = 3;
+
+/// Reverse a TIFF predictor over a freshly decompressed, pixel-interleaved
+/// (chunky) block, in place.
+///
+/// The block is `rows` rows laid out row-major, each `cols` pixels wide with
+/// `spp` samples per pixel and `bps` bytes per sample, bands interleaved. For a
+/// tiled COG pass the full tile geometry (`cols = tile_width`,
+/// `rows = tile_height`); for strips pass the image width and the strip's row
+/// count — the encoder applies the predictor per row across the full (padded)
+/// tile/strip width, so the decode must mirror that. Multi-byte integer samples
+/// are interpreted little-endian, matching the rest of the reader.
+///
+/// Predictor 1 (none) is a no-op. Rows past the bytes actually present (a short
+/// final tile/strip whose codec emitted fewer bytes) are left untouched rather
+/// than treated as an error.
+pub fn undo_predictor(
+    buf: &mut [u8],
+    predictor: u16,
+    cols: usize,
+    rows: usize,
+    spp: usize,
+    bps: usize,
+) -> Result<()> {
+    match predictor {
+        PREDICTOR_NONE => Ok(()),
+        PREDICTOR_HORIZONTAL => undo_horizontal(buf, cols, rows, spp, bps),
+        PREDICTOR_FLOATING_POINT => undo_floating_point(buf, cols, rows, spp, bps),
+        other => Err(GeoTiffError::CorruptData {
+            location: "predictor".into(),
+            message: format!("unsupported TIFF Predictor value {other}"),
+        }),
+    }
+}
+
+/// Iterate the byte ranges of each complete row present in `buf`.
+fn rows_present(buf_len: usize, rows: usize, row_bytes: usize) -> impl Iterator<Item = (usize, usize)> {
+    (0..rows).map(move |r| (r * row_bytes, r * row_bytes + row_bytes)).take_while(move |&(_, end)| end <= buf_len)
+}
+
+/// Reverse horizontal differencing (Predictor 2) for 1-, 2-, or 4-byte integer
+/// samples.
+fn undo_horizontal(buf: &mut [u8], cols: usize, rows: usize, spp: usize, bps: usize) -> Result<()> {
+    let row_bytes = cols * spp * bps;
+    if cols <= 1 || row_bytes == 0 {
+        return Ok(());
+    }
+    let samples = cols * spp; // samples per row
+    for (start, end) in rows_present(buf.len(), rows, row_bytes).collect::<Vec<_>>() {
+        let row = &mut buf[start..end];
+        match bps {
+            1 => {
+                for i in spp..row.len() {
+                    row[i] = row[i].wrapping_add(row[i - spp]);
+                }
+            }
+            2 => {
+                for i in spp..samples {
+                    let prev = u16::from_le_bytes([row[(i - spp) * 2], row[(i - spp) * 2 + 1]]);
+                    let cur = u16::from_le_bytes([row[i * 2], row[i * 2 + 1]]);
+                    row[i * 2..i * 2 + 2].copy_from_slice(&cur.wrapping_add(prev).to_le_bytes());
+                }
+            }
+            4 => {
+                for i in spp..samples {
+                    let p = (i - spp) * 4;
+                    let c = i * 4;
+                    let prev = u32::from_le_bytes([row[p], row[p + 1], row[p + 2], row[p + 3]]);
+                    let cur = u32::from_le_bytes([row[c], row[c + 1], row[c + 2], row[c + 3]]);
+                    row[c..c + 4].copy_from_slice(&cur.wrapping_add(prev).to_le_bytes());
+                }
+            }
+            other => {
+                return Err(GeoTiffError::CorruptData {
+                    location: "predictor".into(),
+                    message: format!(
+                        "horizontal predictor with {other}-byte samples is not supported"
+                    ),
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Reverse the floating-point predictor (Predictor 3) for 4- or 8-byte float
+/// samples: byte-wise horizontal accumulation followed by de-interleaving the
+/// per-row byte planes back into little-endian samples (TIFF Technical Note 3).
+fn undo_floating_point(buf: &mut [u8], cols: usize, rows: usize, spp: usize, bps: usize) -> Result<()> {
+    if bps != 4 && bps != 8 {
+        return Err(GeoTiffError::CorruptData {
+            location: "predictor".into(),
+            message: format!("floating-point predictor requires 4- or 8-byte samples, got {bps}"),
+        });
+    }
+    let samples = cols * spp; // samples per row
+    let row_bytes = samples * bps;
+    if cols == 0 || row_bytes == 0 {
+        return Ok(());
+    }
+    let stride = spp;
+    let mut plane = vec![0u8; row_bytes];
+    for (start, end) in rows_present(buf.len(), rows, row_bytes).collect::<Vec<_>>() {
+        let row = &mut buf[start..end];
+        // 1) Undo byte-wise horizontal differencing across the row (stride = spp).
+        for i in stride..row.len() {
+            row[i] = row[i].wrapping_add(row[i - stride]);
+        }
+        // 2) De-interleave byte planes. The row is stored most-significant byte
+        //    plane first; reassemble each little-endian sample from its planes.
+        plane.copy_from_slice(row);
+        for s in 0..samples {
+            for byte in 0..bps {
+                row[bps * s + byte] = plane[(bps - byte - 1) * samples + s];
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod predictor_tests {
+    use super::*;
+
+    #[test]
+    fn none_is_noop() {
+        let mut buf = vec![5u8, 3, 9, 1];
+        undo_predictor(&mut buf, PREDICTOR_NONE, 4, 1, 1, 1).unwrap();
+        assert_eq!(buf, vec![5, 3, 9, 1]);
+    }
+
+    #[test]
+    fn horizontal_byte_single_band() {
+        // Original row [10, 12, 9, 20]; horizontal differences [10, 2, -3, 11]
+        // stored as wrapping u8: [10, 2, 253, 11].
+        let mut buf = vec![10u8, 2, 253, 11];
+        undo_predictor(&mut buf, PREDICTOR_HORIZONTAL, 4, 1, 1, 1).unwrap();
+        assert_eq!(buf, vec![10, 12, 9, 20]);
+    }
+
+    #[test]
+    fn horizontal_byte_rgb_interleaved() {
+        // Two pixels, 3 bands: original R,G,B = [(10,20,30),(15,18,33)].
+        // Interleaved: [10,20,30, 15,18,33]; differenced per channel:
+        // [10,20,30, 5,-2,3] -> wrapping [10,20,30, 5,254,3].
+        let mut buf = vec![10u8, 20, 30, 5, 254, 3];
+        undo_predictor(&mut buf, PREDICTOR_HORIZONTAL, 2, 1, 3, 1).unwrap();
+        assert_eq!(buf, vec![10, 20, 30, 15, 18, 33]);
+    }
+
+    #[test]
+    fn horizontal_two_rows_independent() {
+        // Each row differenced independently; row boundary must reset accumulation.
+        // Row0 orig [4,7]; diff [4,3]. Row1 orig [200,50]; diff [200, 106] (50-200 mod 256).
+        let mut buf = vec![4u8, 3, 200, 106];
+        undo_predictor(&mut buf, PREDICTOR_HORIZONTAL, 2, 2, 1, 1).unwrap();
+        assert_eq!(buf, vec![4, 7, 200, 50]);
+    }
+
+    #[test]
+    fn horizontal_u16_little_endian() {
+        // Original u16 row [1000, 1005, 1002]; diffs [1000, 5, -3].
+        let mut buf = Vec::new();
+        for v in [1000u16, 5, (-3i32 as u16)] {
+            buf.extend_from_slice(&v.to_le_bytes());
+        }
+        undo_predictor(&mut buf, PREDICTOR_HORIZONTAL, 3, 1, 1, 2).unwrap();
+        let got: Vec<u16> = buf
+            .chunks_exact(2)
+            .map(|c| u16::from_le_bytes([c[0], c[1]]))
+            .collect();
+        assert_eq!(got, vec![1000, 1005, 1002]);
+    }
+
+    #[test]
+    fn floating_point_f32_roundtrip() {
+        // Encode a known f32 row with the fp predictor, then decode and compare.
+        let orig = [1.5f32, -2.25, 100.0, 0.125];
+        let encoded = fp_encode_f32_row(&orig);
+        let mut buf = encoded;
+        undo_predictor(&mut buf, PREDICTOR_FLOATING_POINT, orig.len(), 1, 1, 4).unwrap();
+        let got: Vec<f32> = buf
+            .chunks_exact(4)
+            .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .collect();
+        assert_eq!(got, orig);
+    }
+
+    /// Forward floating-point predictor for one row of little-endian f32 samples
+    /// (test-only, mirrors the TIFF encoder): interleave byte planes MSB-first,
+    /// then byte-wise horizontal difference.
+    fn fp_encode_f32_row(samples: &[f32]) -> Vec<u8> {
+        let n = samples.len();
+        let bps = 4usize;
+        let le: Vec<[u8; 4]> = samples.iter().map(|v| v.to_le_bytes()).collect();
+        // Byte-plane interleave, most-significant byte plane first.
+        let mut planed = vec![0u8; n * bps];
+        for s in 0..n {
+            for byte in 0..bps {
+                planed[(bps - byte - 1) * n + s] = le[s][byte];
+            }
+        }
+        // Byte-wise horizontal difference, stride = spp = 1.
+        for i in (1..planed.len()).rev() {
+            planed[i] = planed[i].wrapping_sub(planed[i - 1]);
+        }
+        planed
+    }
+}
+
 // ── LZW ──────────────────────────────────────────────────────────────────────
 
 mod lzw {

--- a/crates/wbgeotiff/src/reader.rs
+++ b/crates/wbgeotiff/src/reader.rs
@@ -675,6 +675,13 @@ impl GeoTiff {
     fn decode_all_pixels(&self) -> Result<Vec<u8>> {
         let expected_total = self.info.row_bytes() * self.info.height as usize;
 
+        // Predictor stride: chunky rows interleave all bands (stride = spp),
+        // while each planar strip/tile holds a single band (stride = 1).
+        let pred_spp = match self.info.planar_config {
+            PlanarConfig::Chunky => self.info.samples_per_pixel as usize,
+            PlanarConfig::Planar => 1,
+        };
+
         match &self.info.layout {
             ImageLayout::Stripped { rows_per_strip, offsets, byte_counts } => {
                 let mut out = Vec::with_capacity(expected_total);
@@ -700,7 +707,7 @@ impl GeoTiff {
                         self.info.predictor,
                         self.info.width as usize,
                         strip_rows,
-                        self.info.samples_per_pixel as usize,
+                        pred_spp,
                         self.info.bytes_per_sample(),
                     )?;
                     out.extend_from_slice(&decompressed[..decompressed.len().min(expected_strip)]);
@@ -741,7 +748,7 @@ impl GeoTiff {
                             self.info.predictor,
                             tw,
                             th,
-                            spp,
+                            pred_spp,
                             bps,
                         )?;
 
@@ -823,7 +830,9 @@ pub struct CogLevel {
     /// Compression codec.
     pub compression: Compression,
     /// TIFF `Predictor` tag (317); 1 = none, 2 = horizontal, 3 = floating point.
-    pub predictor: u16,
+    /// Private and read only by the decoder so adding it stays a non-breaking
+    /// change for downstream code that constructs or destructures `CogLevel`.
+    predictor: u16,
 }
 
 impl CogLevel {

--- a/crates/wbgeotiff/src/reader.rs
+++ b/crates/wbgeotiff/src/reader.rs
@@ -42,6 +42,8 @@ struct ImageInfo {
     bits_per_sample: u16,
     sample_format: SampleFormat,
     compression: Compression,
+    /// TIFF `Predictor` tag (317); 1 = none, 2 = horizontal, 3 = floating point.
+    predictor: u16,
     photometric: PhotometricInterpretation,
     planar_config: PlanarConfig,
     no_data: Option<f64>,
@@ -227,6 +229,13 @@ impl GeoTiff {
             .map(|v| Compression::from_tag(v as u16))
             .unwrap_or(Compression::None);
 
+        // Predictor (317): 1 = none (default), 2 = horizontal differencing,
+        // 3 = floating point. Reversed after decompression before samples are read.
+        let predictor = ifd
+            .get(tag::Predictor)
+            .and_then(|e| e.value.as_u64())
+            .unwrap_or(1) as u16;
+
         let photometric = ifd
             .get(tag::PhotometricInterpretation)
             .and_then(|e| e.value.as_u64())
@@ -276,6 +285,7 @@ impl GeoTiff {
             bits_per_sample,
             sample_format,
             compression,
+            predictor,
             photometric,
             planar_config,
             no_data,
@@ -683,8 +693,16 @@ impl GeoTiff {
                     let compressed = &self.data[start..end];
                     let strip_rows = rps.min(self.info.height as usize - i * rps);
                     let expected_strip = strip_rows * row_bytes;
-                    let decompressed =
+                    let mut decompressed =
                         compression::decompress(self.info.compression, compressed, expected_strip)?;
+                    compression::undo_predictor(
+                        &mut decompressed,
+                        self.info.predictor,
+                        self.info.width as usize,
+                        strip_rows,
+                        self.info.samples_per_pixel as usize,
+                        self.info.bytes_per_sample(),
+                    )?;
                     out.extend_from_slice(&decompressed[..decompressed.len().min(expected_strip)]);
                 }
                 Ok(out)
@@ -716,8 +734,16 @@ impl GeoTiff {
                             });
                         }
                         let compressed = &self.data[off..off + bc];
-                        let decompressed =
+                        let mut decompressed =
                             compression::decompress(self.info.compression, compressed, tile_bytes_raw)?;
+                        compression::undo_predictor(
+                            &mut decompressed,
+                            self.info.predictor,
+                            tw,
+                            th,
+                            spp,
+                            bps,
+                        )?;
 
                         // Copy tile into the output buffer, clipping at image edges
                         let img_x0 = tx * tw;
@@ -796,6 +822,8 @@ pub struct CogLevel {
     pub sample_format: SampleFormat,
     /// Compression codec.
     pub compression: Compression,
+    /// TIFF `Predictor` tag (317); 1 = none, 2 = horizontal, 3 = floating point.
+    pub predictor: u16,
 }
 
 impl CogLevel {
@@ -818,7 +846,16 @@ impl CogLevel {
         let bps = (self.bits_per_sample as usize + 7) / 8;
         let spp = self.samples_per_pixel as usize;
         let raw = self.tile_width as usize * self.tile_height as usize * spp * bps;
-        let decompressed = compression::decompress(self.compression, tile_bytes, raw)?;
+        let mut decompressed = compression::decompress(self.compression, tile_bytes, raw)?;
+        // Undo any TIFF predictor across each full tile row before reading samples.
+        compression::undo_predictor(
+            &mut decompressed,
+            self.predictor,
+            self.tile_width as usize,
+            self.tile_height as usize,
+            spp,
+            bps,
+        )?;
         let mut out = Vec::with_capacity(raw / bps.max(1));
         for chunk in decompressed.chunks_exact(bps.max(1)) {
             out.push(sample_to_f64(chunk, self.sample_format).unwrap_or(f64::NAN));
@@ -876,6 +913,7 @@ impl GeoTiff {
                         bits_per_sample: info.bits_per_sample,
                         sample_format: info.sample_format,
                         compression: info.compression,
+                        predictor: info.predictor,
                     });
                 }
                 ImageLayout::Stripped { .. } => {

--- a/crates/wbgeotiff/src/tags.rs
+++ b/crates/wbgeotiff/src/tags.rs
@@ -23,6 +23,7 @@ pub mod tag {
     pub const YResolution: u16 = 283;
     pub const PlanarConfiguration: u16 = 284;
     pub const ResolutionUnit: u16 = 296;
+    pub const Predictor: u16 = 317;
     pub const Software: u16 = 305;
     pub const DateTime: u16 = 306;
     pub const SampleFormat: u16 = 339;


### PR DESCRIPTION
## Problem

COGs written with **`PREDICTOR=2`** (horizontal differencing) or **`PREDICTOR=3`** (floating point) — GDAL's default for Deflate/LZW imagery such as NAIP tiles — decoded to garbage. Both tile/strip decoders inflated the compressed stream but never undid the predictor, so every sample was left as its residual difference from the previous pixel in the row. Visually this is high-frequency, edge-tracking noise that faintly traces the real image.

The default `PREDICTOR=1` (none) was unaffected, which is why single-band DEMs (Deflate, predictor 1) rendered fine while 4-band NAIP RGB (Deflate, predictor 2) did not.

## Fix

- **`tags.rs`** — add the `Predictor` tag (317).
- **`compression.rs`** — add `undo_predictor`, reversing the predictor over a freshly decompressed, pixel-interleaved block, per row across the full (padded) tile/strip width:
  - Predictor 2 (horizontal) for 1-, 2-, and 4-byte integer samples (little-endian, per-channel stride = samples/pixel).
  - Predictor 3 (floating point) for 4- and 8-byte floats (byte-plane horizontal accumulation + de-interleave, per TIFF Technical Note 3).
  - Predictor 1 stays a no-op.
- **`reader.rs`** — parse `Predictor` into `ImageInfo` and `CogLevel`, and apply `undo_predictor` after decompression in both decode paths: `CogLevel::decode_tile_f64` (streaming tile path) and `GeoTiff::decode_all_pixels` (whole-image, tiled + stripped).

## Tests

- `cargo test -p wbgeotiff` → 37 pass (31 existing + 6 new). New tests cover byte and u16 horizontal differencing, interleaved multi-band pixels, per-row independence, and an f32 floating-point round trip.
- Verified end-to-end in a browser via `cog-tiler-wasm` + `maplibre-gl-raster`: a Deflate+Predictor=2 NAIP COG (and the full `naip_water_train.vrt` mosaic) that previously rendered as noise now renders as correct RGB aerial imagery.

## Downstream

No API change. After release, bump `whitebox-wasm` in `cog-tiler-wasm`, then `cog-tiler-wasm` in `maplibre-gl-raster`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for TIFF Predictor tags during image decoding.
  * Improved compatibility with predictor-encoded strip and tile data, including floating-point samples.
  * Extended cloud-optimized GeoTIFF streaming to correctly decode predictor-encoded tiles.

* **Bug Fixes**
  * Corrected pixel values for TIFF files that use horizontal differencing or floating-point prediction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->