### PR TITLE
chore(release): whitebox-wasm 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3558,7 +3558,7 @@ dependencies = [
 
 [[package]]
 name = "whitebox-wasm"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",

--- a/crates/whitebox-wasm/Cargo.toml
+++ b/crates/whitebox-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whitebox-wasm"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 description = "Pure-Rust geospatial toolkit (raster, vector, LiDAR, projections) compiled to WebAssembly"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Version bump for the topology fixes (#9, #10). Minor bump since the validation report's issue-type set and autofix behavior changed. Tagging v0.5.0 after merge triggers the npm release workflow.