### PR TITLE
fix(wasm): stop 14 tools trapping on wasm32 by routing fan-outs through dispatch_worker

### DIFF
--- a/.github/workflows/wasi.yml
+++ b/.github/workflows/wasi.yml
@@ -22,3 +22,21 @@ jobs:
         run: curl https://wasmtime.dev/install.sh -sSf | bash
       - name: Smoke test (list tools)
         run: ~/.wasmtime/bin/wasmtime run target/wasm32-wasip1/release/whitebox.wasm list | head -1
+      - name: Smoke test (tools that fan work out to worker threads)
+        # wasm32 cannot spawn threads: `wasm32-wasip1` fails with errno 58
+        # (Unsupported), which std unwraps into a panic and therefore an
+        # `unreachable` trap. Tools that fan out must degrade to the serial
+        # path instead. Running `list` alone never exercised any of that, which
+        # is how a whole family of tools shipped broken in the browser. One tool
+        # per fan-out helper, so a regression in either is caught.
+        run: |
+          mkdir -p work && cp examples/sample.tif work/dem.tif
+          wasm=target/wasm32-wasip1/release/whitebox.wasm
+          run() { ~/.wasmtime/bin/wasmtime run --dir work::/work "$wasm" "$@"; }
+          run sky_view_factor --dem=/work/dem.tif --output=/work/svf.tif
+          run find_noflow_cells --input=/work/dem.tif --output=/work/noflow.tif
+          run plan_curvature --input=/work/dem.tif --output=/work/planc.tif
+          run pennock_landform_classification --input=/work/dem.tif --output=/work/pennock.tif
+          for f in svf noflow planc pennock; do
+            test -s "work/$f.tif" || { echo "::error::$f.tif was not written"; exit 1; }
+          done

--- a/crates/wbtools_oss/src/tools/geomorphometry/curvature_tools.rs
+++ b/crates/wbtools_oss/src/tools/geomorphometry/curvature_tools.rs
@@ -875,7 +875,7 @@ impl PlanCurvatureTool {
                     for worker_id in 0..num_workers {
                         let tx = tx.clone();
                         let input = &input;
-                        scope.spawn(move || {
+                        crate::tools::dispatch_scoped_worker(num_workers > 1, scope, move || {
                             for row_idx in (worker_id..rows).step_by(num_workers) {
                                 let mut row_out = vec![nodata; cols];
                                 let row = row_idx as isize;
@@ -921,7 +921,7 @@ impl PlanCurvatureTool {
                     for worker_id in 0..num_workers {
                         let tx = tx.clone();
                         let band_buf = Arc::clone(&band_buf);
-                        scope.spawn(move || {
+                        crate::tools::dispatch_scoped_worker(num_workers > 1, scope, move || {
                             for row_idx in (worker_id..rows).step_by(num_workers) {
                                 let mut row_out = vec![nodata; cols];
                                 let row = row_idx as isize;

--- a/crates/wbtools_oss/src/tools/geomorphometry/sky_visibility_tools.rs
+++ b/crates/wbtools_oss/src/tools/geomorphometry/sky_visibility_tools.rs
@@ -589,7 +589,7 @@ impl SkyVisibilityCore {
             let tx = tx.clone();
             let dem = dem.clone();
             let offsets = offsets.clone();
-            thread::spawn(move || {
+            crate::tools::dispatch_worker(num_threads > 1, move || {
                 for row in (0..rows).filter(|r| r % num_threads == tid) {
                     let mut data = vec![nodata_f32 as f64; cols as usize];
                     for col in 0..cols {
@@ -749,7 +749,7 @@ impl SkyVisibilityCore {
                 let tx = tx.clone();
                 let dem = dem.clone();
                 let offsets = offsets.clone();
-                thread::spawn(move || {
+                crate::tools::dispatch_worker(num_threads > 1, move || {
                     for row in (0..rows).filter(|r| r % num_threads == tid) {
                         let mut data = vec![nodata; cols as usize];
                         let mut n = vec![0_u8; cols as usize];
@@ -936,7 +936,7 @@ impl SkyVisibilityCore {
         for tid in 0..num_threads {
             let dem = dem.clone();
             let tx = tx.clone();
-            thread::spawn(move || {
+            crate::tools::dispatch_worker(num_threads > 1, move || {
                 let mut local_counts = vec![0_u32; (rows * cols) as usize];
                 let mut view_angle = vec![-32768.0_f32; (rows * cols) as usize];
                 let mut max_view_angle = vec![-32768.0_f32; (rows * cols) as usize];
@@ -1475,7 +1475,7 @@ impl SkyVisibilityCore {
                 let tx = tx.clone();
                 let dem = dem.clone();
                 let offsets = offsets.clone();
-                thread::spawn(move || {
+                crate::tools::dispatch_worker(num_threads > 1, move || {
                     for row in (0..rows).filter(|r| r % num_threads == tid) {
                         let mut row_x = vec![nodata_f32; cols as usize];
                         let mut row_y = vec![nodata_f32; cols as usize];
@@ -4056,7 +4056,7 @@ impl SkyVisibilityCore {
                 let tx = tx.clone();
                 let dem = dem.clone();
                 let offsets = offsets.clone();
-                thread::spawn(move || {
+                crate::tools::dispatch_worker(num_threads > 1, move || {
                     for row in (0..rows).filter(|r| r % num_threads == tid) {
                         let mut data = vec![nodata; cols as usize];
                         let mut n = vec![0_u8; cols as usize];
@@ -4276,7 +4276,7 @@ impl SkyVisibilityCore {
                 let tx = tx.clone();
                 let dem = dem.clone();
                 let offsets = offsets.clone();
-                thread::spawn(move || {
+                crate::tools::dispatch_worker(num_threads > 1, move || {
                     for row in (0..rows).filter(|r| r % num_threads == tid) {
                         let mut ha_row = vec![nodata_f32; cols as usize];
                         for col in 0..cols {

--- a/crates/wbtools_oss/src/tools/geomorphometry/terrain_analysis_tools.rs
+++ b/crates/wbtools_oss/src/tools/geomorphometry/terrain_analysis_tools.rs
@@ -3879,7 +3879,7 @@ impl TerrainAnalysisCore {
             for tid in 0..num_workers {
                 let tx = tx.clone();
                 let input = &input;
-                scope.spawn(move || {
+                crate::tools::dispatch_scoped_worker(num_workers > 1, scope, move || {
                     // Inline nodata check — avoids epsilon arithmetic in is_nodata() per pixel.
                     let is_nd = |v: f64| -> bool {
                         if nodata_is_nan { v.is_nan() } else { v == nodata }

--- a/crates/wbtools_oss/src/tools/hydrology/find_noflow_cells.rs
+++ b/crates/wbtools_oss/src/tools/hydrology/find_noflow_cells.rs
@@ -100,7 +100,7 @@ impl Tool for FindNoflowCellsTool {
         for tid in 0..num_procs {
             let view = view.clone();
             let tx = tx.clone();
-            thread::spawn(move || {
+            crate::tools::dispatch_worker(num_procs > 1, move || {
                 for row in (0..rows).filter(|r| r % num_procs == tid) {
                     let mut row_data = vec![nodata; cols as usize];
 

--- a/crates/wbtools_oss/src/tools/mod.rs
+++ b/crates/wbtools_oss/src/tools/mod.rs
@@ -5,12 +5,14 @@ use wbcore::ToolParamSchema;
 /// Runs `work` on a background thread on native targets, or inline on the
 /// current thread when `parallel` is `false` or when compiling for wasm32.
 ///
-/// `std::thread::spawn` is unsupported on `wasm32-unknown-unknown`: calling it
-/// at runtime traps with `unreachable`, which is why the threaded flow-routing
-/// helpers (D8 pointer, D8/FD8 accumulation, basins, ...) crashed in the
-/// browser/WASI runtime while the fully-serial composite workflow kept working.
-/// Routing every worker fan-out through this helper keeps the multi-threaded
-/// fast path on native CLI builds while degrading to a serial loop on wasm.
+/// `std::thread::spawn` is unsupported on every wasm32 target we ship:
+/// `wasm32-unknown-unknown` traps outright, and `wasm32-wasip1` returns
+/// `Unsupported` (errno 58), which `spawn` unwraps into a panic and therefore
+/// an `unreachable` trap. That is why the threaded flow-routing helpers (D8
+/// pointer, D8/FD8 accumulation, basins, ...) crashed in the browser/WASI
+/// runtime while the fully-serial composite workflow kept working. Routing
+/// every worker fan-out through this helper keeps the multi-threaded fast path
+/// on native CLI builds while degrading to a serial loop on wasm.
 ///
 /// Callers use the established `mpsc` fan-out pattern (each worker sends its
 /// rows down a channel that the caller drains), so running inline is safe: the
@@ -28,6 +30,32 @@ where
 		}
 	}
 	let _ = parallel;
+	work();
+}
+
+/// Scoped counterpart of [`dispatch_worker`], for fan-outs whose workers borrow
+/// from the enclosing frame (`std::thread::scope` + `scope.spawn`) instead of
+/// owning `'static` data.
+///
+/// `scope.spawn` goes through the same unsupported OS primitive as
+/// `std::thread::spawn`, so it traps on wasm32 exactly the same way. Callers
+/// keep the `mpsc` fan-out pattern and drain the channel after the scope ends,
+/// so running inline is safe for the same reason it is in `dispatch_worker`.
+pub(crate) fn dispatch_scoped_worker<'scope, 'env, F>(
+	parallel: bool,
+	scope: &'scope std::thread::Scope<'scope, 'env>,
+	work: F,
+) where
+	F: FnOnce() + Send + 'scope,
+{
+	#[cfg(not(target_arch = "wasm32"))]
+	{
+		if parallel {
+			scope.spawn(work);
+			return;
+		}
+	}
+	let _ = (parallel, scope);
 	work();
 }
 


### PR DESCRIPTION
## Problem

Fourteen tools abort with a bare `unreachable` trap as soon as they are run on
a wasm32 target. Reported downstream as
[opengeos/geolibre-rust#505](https://github.com/opengeos/geolibre-rust/issues/505)
against `time_in_daylight`, with a note that other tools fail the same way.

The trap is a Rust panic:

```
thread 'main' (1) panicked at library/std/src/thread/functions.rs:131:29:
failed to spawn thread: Os { code: 58, kind: Unsupported, message: "Not supported" }
```

`std::thread::spawn` cannot work on wasm32: `wasm32-unknown-unknown` traps
outright, and `wasm32-wasip1` returns `Unsupported` (errno 58), which `spawn`
unwraps into a panic and therefore an `unreachable` trap.

`tools::dispatch_worker` already exists for exactly this reason — it was added
when the flow-routing helpers hit it. But nine fan-out sites were never routed
through it, and three of them use `std::thread::scope` + `scope.spawn`, which
`dispatch_worker` can't accept because scoped workers borrow rather than own
their data.

## Affected tools

Each one traps 100% of the time on wasm; none of them has ever worked in the
browser or under WASI.

| Source | Tools |
| --- | --- |
| `sky_visibility_tools.rs` | `horizon_angle`, `sky_view_factor`, `visibility_index`, `horizon_area`, `average_horizon_distance`, `time_in_daylight` |
| `find_noflow_cells.rs` | `find_noflow_cells` |
| `curvature_tools.rs` (scoped) | `plan_curvature`, `profile_curvature`, `tangential_curvature`, `total_curvature`, `mean_curvature`, `gaussian_curvature` — all six share one impl |
| `terrain_analysis_tools.rs` (scoped) | `pennock_landform_classification` |

## Fix

- Route the six raw `thread::spawn` calls through the existing
  `dispatch_worker`.
- Add `dispatch_scoped_worker`, the scoped counterpart of `dispatch_worker`, and
  route the three `scope.spawn` calls through it.

Native builds keep the multi-threaded fast path unchanged; wasm degrades to the
serial loop. Running inline is safe for the same reason it already is in
`dispatch_worker`: every one of these fan-outs uses an unbounded `mpsc` channel
and drains it only after the workers are done, so an inline send can never
block. I checked — there are no `sync_channel` (bounded) fan-outs in the crate.
Every receiver also places results by the row index carried in the message
rather than by arrival order, so serialising the workers cannot reorder output.

## Regression test

The `WASI CLI` job built the runner and then only ran `list`, so it never
executed a single tool — which is how a whole family of tools shipped broken.
It now runs one tool per fan-out helper against the existing
`examples/sample.tif` fixture and asserts each output was written. Verified that
the fixture reproduces all three trap families on the unpatched build.

## Verification

Against a `wasm32-wasip1` build driven through the same
`@bjorn3/browser_wasi_shim` the browser uses:

| | before | after |
| --- | --- | --- |
| `time_in_daylight` | trap | writes output |
| `sky_view_factor` | trap | writes output |
| `horizon_angle`, `visibility_index`, `horizon_area`, `average_horizon_distance` | trap | writes output |
| `find_noflow_cells` | trap | writes output |
| `plan_curvature` | trap | writes output |
| `pennock_landform_classification` | trap | writes output |
| `slope`, `aspect` (rayon controls) | ok | ok |

`cargo check` passes on both the host and `wasm32-wasip1`, and the new CI step
was run locally under wasmtime exactly as written.

## Known limitation

Serial is correct but it is not fast. On a 2880x1773 DEM, `time_in_daylight`
(72 azimuth bins x a full-raster horizon trace per bin) did not finish inside
400s under WASI, where before it failed instantly. That is inherent to wasm
having no threads — the alternative is the tool staying broken — but it is
worth knowing that the horizon/daylight family is only practical on modest
rasters in the browser.

## Note

`crates/wbtools_oss/src/tools/lidar_processing/individual_tree_detection.rs`
has the same raw `thread::spawn` pattern, but no `mod` declaration references
it, so it is not compiled. The registered `IndividualTreeDetectionTool` is the
one in `lidar_processing/mod.rs`, which does not spawn and runs fine on wasm.
Left alone rather than "fixing" dead code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility for WASI and browser-based environments by safely handling tools that use worker threads.
  - Geomorphometry and hydrology tools now fall back to serial processing when multiple threads are unavailable, preventing runtime failures.
  - Added smoke tests verifying successful output generation for affected tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->