### PR TITLE
chore(release): whitebox-wasm 0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3558,7 +3558,7 @@ dependencies = [
 
 [[package]]
 name = "whitebox-wasm"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",

--- a/crates/whitebox-wasm/Cargo.toml
+++ b/crates/whitebox-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whitebox-wasm"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 description = "Pure-Rust geospatial toolkit (raster, vector, LiDAR, projections) compiled to WebAssembly"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Patch release for #13.

Fourteen tools aborted with an `unreachable` trap the moment they ran on a wasm32 target — the sky-visibility family (including `time_in_daylight`), the six curvature tools, `find_noflow_cells`, and `pennock_landform_classification`. Their worker fan-outs called `std::thread::spawn` / `scope.spawn` directly, which wasm32 cannot do; they now degrade to a serial loop like the rest of the suite.

Patch rather than minor: nothing changes on native targets — same API, same threaded fast path.

Reported downstream as opengeos/geolibre-rust#505. Tag `v0.5.1` follows once this merges.