### PR TITLE
chore(release): whitebox-wasm 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3558,7 +3558,7 @@ dependencies = [
 
 [[package]]
 name = "whitebox-wasm"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",

--- a/crates/whitebox-wasm/Cargo.toml
+++ b/crates/whitebox-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whitebox-wasm"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2021"
 description = "Pure-Rust geospatial toolkit (raster, vector, LiDAR, projections) compiled to WebAssembly"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Minor release for the trailing-directory COG header support (#15).

`CogStream` could only read a header out of front-of-file bytes, which is all a
Cloud Optimized GeoTIFF ever needs. A plain GeoTIFF, as GDAL and libtiff write
one by default, puts its directory after the pixel data, so callers growing a
front prefix hit "failed to fill whole buffer" instead.

Adds two entry points: `first_ifd_offset(headerBytes)` and
`CogStream.from_windows(prefix, tailOffset, tail)`. New API, so minor rather
than patch; nothing existing changed behavior.

Reported downstream as opengeos/GeoLibre#1743.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the whitebox-wasm package version to 0.6.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->