### PR TITLE
fix(vector): close polygon rings when tracing them as lines

### DIFF
--- a/crates/wbtools_oss/src/tools/data_tools/mod.rs
+++ b/crates/wbtools_oss/src/tools/data_tools/mod.rs
@@ -442,6 +442,19 @@ fn close_ring(coords: &[wbvector::Coord]) -> Vec<wbvector::Coord> {
     ring
 }
 
+/// Traces a polygon ring as a linestring.
+///
+/// `Ring` stores its vertices open, without the closing duplicate point, so a
+/// straight copy of the coordinates loses the final segment from the last
+/// vertex back to the first. Degenerate rings are passed through untouched
+/// rather than closed into a doubled-back stub.
+fn ring_boundary_line(ring: &Ring) -> Vec<Coord> {
+    if ring.0.len() < 3 {
+        return ring.0.clone();
+    }
+    close_ring(&ring.0)
+}
+
 fn strip_polygon_holes_with_topology(geometry: &Geometry) -> Result<Geometry, ToolError> {
     let topo_geom = topology_from_wkb(&geometry.to_wkb())
         .map_err(|e| ToolError::Execution(format!("failed converting geometry for topology processing: {e}")))?;
@@ -968,22 +981,22 @@ fn geometry_line_parts(geometry: &Geometry, out: &mut Vec<Vec<Coord>>) {
         }
         Geometry::Polygon { exterior, interiors } => {
             if exterior.0.len() >= 2 {
-                out.push(exterior.0.clone());
+                out.push(ring_boundary_line(exterior));
             }
             for ring in interiors {
                 if ring.0.len() >= 2 {
-                    out.push(ring.0.clone());
+                    out.push(ring_boundary_line(ring));
                 }
             }
         }
         Geometry::MultiPolygon(polys) => {
             for (exterior, interiors) in polys {
                 if exterior.0.len() >= 2 {
-                    out.push(exterior.0.clone());
+                    out.push(ring_boundary_line(exterior));
                 }
                 for ring in interiors {
                     if ring.0.len() >= 2 {
-                        out.push(ring.0.clone());
+                        out.push(ring_boundary_line(ring));
                     }
                 }
             }
@@ -3772,18 +3785,18 @@ impl Tool for PolygonsToLinesTool {
             .map(|feature| {
                 let geom = match &feature.geometry {
                     Some(Geometry::Polygon { exterior, interiors }) => {
-                        let mut lines = vec![exterior.0.clone()];
+                        let mut lines = vec![ring_boundary_line(exterior)];
                         for ring in interiors {
-                            lines.push(ring.0.clone());
+                            lines.push(ring_boundary_line(ring));
                         }
                         Some(Geometry::multi_line_string(lines))
                     }
                     Some(Geometry::MultiPolygon(polys)) => {
                         let mut lines = Vec::new();
                         for (exterior, interiors) in polys {
-                            lines.push(exterior.0.clone());
+                            lines.push(ring_boundary_line(exterior));
                             for ring in interiors {
-                                lines.push(ring.0.clone());
+                                lines.push(ring_boundary_line(ring));
                             }
                         }
                         Some(Geometry::multi_line_string(lines))
@@ -7477,5 +7490,94 @@ mod polygon_topology_issue_tests {
         // Two-vertex hole: too short.
         let short = issue_types(exterior, vec![ring(vec![c(1.0, 1.0), c(2.0, 1.0)])]);
         assert!(short.contains(&"polygon_hole_too_short".to_string()));
+    }
+}
+
+#[cfg(test)]
+mod ring_boundary_line_tests {
+    use super::*;
+
+    fn c(x: f64, y: f64) -> Coord {
+        Coord::xy(x, y)
+    }
+
+    fn square() -> Ring {
+        Ring::new(vec![c(0.0, 0.0), c(10.0, 0.0), c(10.0, 10.0), c(0.0, 10.0)])
+    }
+
+    #[test]
+    fn open_ring_gains_the_closing_vertex() {
+        let line = ring_boundary_line(&square());
+        assert_eq!(line.len(), 5, "the traced boundary must return to its start");
+        assert_eq!(line.first().map(|p| (p.x, p.y)), Some((0.0, 0.0)));
+        assert_eq!(line.last().map(|p| (p.x, p.y)), Some((0.0, 0.0)));
+    }
+
+    #[test]
+    fn already_closed_ring_is_not_doubled() {
+        let closed = Ring::new(vec![
+            c(0.0, 0.0),
+            c(10.0, 0.0),
+            c(10.0, 10.0),
+            c(0.0, 10.0),
+            c(0.0, 0.0),
+        ]);
+        assert_eq!(ring_boundary_line(&closed).len(), 5);
+    }
+
+    #[test]
+    fn degenerate_rings_are_passed_through() {
+        assert!(ring_boundary_line(&Ring::new(Vec::new())).is_empty());
+        assert_eq!(ring_boundary_line(&Ring::new(vec![c(1.0, 1.0)])).len(), 1);
+        assert_eq!(
+            ring_boundary_line(&Ring::new(vec![c(1.0, 1.0), c(2.0, 2.0)])).len(),
+            2
+        );
+    }
+
+    #[test]
+    fn polygons_to_lines_traces_the_whole_boundary() {
+        let hole = vec![c(2.0, 2.0), c(4.0, 2.0), c(4.0, 4.0), c(2.0, 4.0)];
+        let geom = Geometry::Polygon {
+            exterior: square(),
+            interiors: vec![Ring::new(hole)],
+        };
+        let Geometry::Polygon { exterior, interiors } = &geom else {
+            panic!("expected a polygon");
+        };
+        let mut lines = vec![ring_boundary_line(exterior)];
+        for ring in interiors {
+            lines.push(ring_boundary_line(ring));
+        }
+        assert_eq!(lines.len(), 2);
+        for line in &lines {
+            assert_eq!(
+                line.first().map(|p| (p.x, p.y)),
+                line.last().map(|p| (p.x, p.y)),
+                "every ring must be traced as a closed line"
+            );
+        }
+    }
+
+    #[test]
+    fn geometry_line_parts_closes_polygon_rings() {
+        let geom = Geometry::Polygon {
+            exterior: square(),
+            interiors: Vec::new(),
+        };
+        let mut parts: Vec<Vec<Coord>> = Vec::new();
+        geometry_line_parts(&geom, &mut parts);
+        assert_eq!(parts.len(), 1);
+        assert_eq!(parts[0].len(), 5);
+        assert_eq!(parts[0].first().map(|p| (p.x, p.y)), Some((0.0, 0.0)));
+        assert_eq!(parts[0].last().map(|p| (p.x, p.y)), Some((0.0, 0.0)));
+    }
+
+    #[test]
+    fn geometry_line_parts_leaves_linestrings_open() {
+        let geom = Geometry::line_string(vec![c(0.0, 0.0), c(1.0, 1.0), c(2.0, 0.0)]);
+        let mut parts: Vec<Vec<Coord>> = Vec::new();
+        geometry_line_parts(&geom, &mut parts);
+        assert_eq!(parts, vec![vec![c(0.0, 0.0), c(1.0, 1.0), c(2.0, 0.0)]]);
     }
 }

--- a/crates/wbtools_oss/src/tools/hydrology/mod.rs
+++ b/crates/wbtools_oss/src/tools/hydrology/mod.rs
@@ -2416,47 +2416,43 @@ fn rasterize_line_geometry(mask: &mut [u8], rows: usize, cols: usize, dem: &Rast
 	}
 }
 
+/// Burns one polygon ring into the boundary mask.
+///
+/// Rings are stored open, without the closing duplicate point, so walking them
+/// with `windows(2)` alone leaves the segment from the last vertex back to the
+/// first unburned and the mask ends up with a gap in it.
+fn rasterize_ring_boundary(mask: &mut [u8], rows: usize, cols: usize, dem: &Raster, ring: &wbvector::Ring) {
+	let n = ring.0.len();
+	if n < 2 {
+		return;
+	}
+	let closed = ring.0[0] == ring.0[n - 1];
+	let segments = if closed { n - 1 } else { n };
+	for i in 0..segments {
+		let a = &ring.0[i];
+		let b = &ring.0[(i + 1) % n];
+		if let (Some((c0, r0)), Some((c1, r1))) = (
+			dem.world_to_pixel(a.x, a.y),
+			dem.world_to_pixel(b.x, b.y),
+		) {
+			draw_line_cells(mask, rows, cols, r0, c0, r1, c1);
+		}
+	}
+}
+
 fn rasterize_polygon_boundaries(mask: &mut [u8], rows: usize, cols: usize, dem: &Raster, geom: &wbvector::Geometry) {
 	match geom {
 		wbvector::Geometry::Polygon { exterior, interiors } => {
-			for seg in exterior.0.windows(2) {
-				if let (Some((c0, r0)), Some((c1, r1))) = (
-					dem.world_to_pixel(seg[0].x, seg[0].y),
-					dem.world_to_pixel(seg[1].x, seg[1].y),
-				) {
-					draw_line_cells(mask, rows, cols, r0, c0, r1, c1);
-				}
-			}
+			rasterize_ring_boundary(mask, rows, cols, dem, exterior);
 			for ring in interiors {
-				for seg in ring.0.windows(2) {
-					if let (Some((c0, r0)), Some((c1, r1))) = (
-						dem.world_to_pixel(seg[0].x, seg[0].y),
-						dem.world_to_pixel(seg[1].x, seg[1].y),
-					) {
-						draw_line_cells(mask, rows, cols, r0, c0, r1, c1);
-					}
-				}
+				rasterize_ring_boundary(mask, rows, cols, dem, ring);
 			}
 		}
 		wbvector::Geometry::MultiPolygon(polys) => {
 			for (exterior, interiors) in polys {
-				for seg in exterior.0.windows(2) {
-					if let (Some((c0, r0)), Some((c1, r1))) = (
-						dem.world_to_pixel(seg[0].x, seg[0].y),
-						dem.world_to_pixel(seg[1].x, seg[1].y),
-					) {
-						draw_line_cells(mask, rows, cols, r0, c0, r1, c1);
-					}
-				}
+				rasterize_ring_boundary(mask, rows, cols, dem, exterior);
 				for ring in interiors {
-					for seg in ring.0.windows(2) {
-						if let (Some((c0, r0)), Some((c1, r1))) = (
-							dem.world_to_pixel(seg[0].x, seg[0].y),
-							dem.world_to_pixel(seg[1].x, seg[1].y),
-						) {
-							draw_line_cells(mask, rows, cols, r0, c0, r1, c1);
-						}
-					}
+					rasterize_ring_boundary(mask, rows, cols, dem, ring);
 				}
 			}
 		}


### PR DESCRIPTION
Reported at opengeos/GeoLibre#1958 (discussion): converting a polygon to a polyline leaves the last segment missing.

## Root cause

`wbvector::Ring` stores its vertices **open**, without the closing duplicate point (`crates/wbvector/src/geometry.rs`), and the GeoJSON reader strips the closing vertex on the way in. Three call sites copied `ring.0` straight into a linestring, so the segment from the last vertex back to the first was never emitted:

- `polygons_to_lines` - a square came back as a 4-point open path instead of a 5-point closed boundary.
- `vector_lines_to_raster` via `geometry_line_parts` - the tool documents polygon input and burns boundaries, so the raster had a gap along the closing segment.
- `rasterize_polygon_boundaries` in `hydrology` - same gap in the boundary mask.

## Fix

A `ring_boundary_line` helper closes a ring before it is traced. Already-closed rings are not doubled, and degenerate rings (fewer than 3 vertices) pass through untouched rather than becoming a doubled-back stub. The hydrology rasterizer gets the equivalent `rasterize_ring_boundary` helper, which also replaces four copies of the same segment-walking loop.

## Verification

Before, on a 10x10 square:

```json
"coordinates": [[[0,0],[10,0],[10,10],[0,10]]]
```

After, through the real GeoJSON reader/writer path (`whitebox polygons_to_lines`), including a polygon with a hole:

```json
"coordinates": [[[20,0],[30,0],[30,10],[20,10],[20,0]],
                [[22,2],[24,2],[24,4],[22,4],[22,2]]]
```

Six new unit tests cover the helper, `geometry_line_parts` on polygons and on linestrings, the already-closed case, and the degenerate cases.

`cargo test -p wbgeotiff -p whitebox-wasm` (what CI runs) is green. `cargo test -p wbtools_oss` goes from 233 to 239 passing; the same 6 failures (lidar, remote sensing, terrain) are present on `main` before this change and are unrelated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved polygon boundary handling so closing segments between the final and first vertices are preserved.
  - Fixed gaps when rasterizing polygon and multipolygon boundaries, including exterior and interior rings.
  - Preserved degenerate rings without introducing invalid geometry.
  - Improved consistency when extracting line parts and converting polygons or linestrings to boundaries.

- **Tests**
  - Added coverage for open, closed, degenerate, polygon, multipolygon, and linestring boundary behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->