### PR TITLE
fix(geojson,topojson): decode string bytes as UTF-8

### DIFF
--- a/crates/wbvector/src/geojson/mod.rs
+++ b/crates/wbvector/src/geojson/mod.rs
@@ -130,9 +130,30 @@ impl<'a> Parser<'a> {
         }
     }
 
+    /// Reads the four hex digits of a `\u` escape, leaving `pos` after them.
+    fn parse_hex4(&mut self) -> Result<u32> {
+        if self.pos + 4 > self.src.len() {
+            return Err(self.err("truncated \\u escape"));
+        }
+        let hex = std::str::from_utf8(&self.src[self.pos..self.pos + 4])
+            .map_err(|_| self.err("invalid \\u escape"))?;
+        let cp = u32::from_str_radix(hex, 16).map_err(|_| self.err("invalid \\u codepoint"))?;
+        self.pos += 4;
+        Ok(cp)
+    }
+
+    /// Parses a JSON string. The source is UTF-8, so unescaped bytes are copied
+    /// through verbatim and decoded once at the end: pushing each byte as a
+    /// `char` would read it as a Latin-1 code point and re-encode it, turning
+    /// every non-ASCII character into mojibake ("Céréales" -> "CÃ©rÃ©ales") in
+    /// every property value and key a tool reads (opengeos/GeoLibre#1977).
     fn parse_string(&mut self) -> Result<String> {
         self.eat(b'"')?;
-        let mut s = String::new();
+        let mut buf: Vec<u8> = Vec::new();
+        let mut push_char = |buf: &mut Vec<u8>, ch: char| {
+            let mut utf8 = [0u8; 4];
+            buf.extend_from_slice(ch.encode_utf8(&mut utf8).as_bytes());
+        };
         loop {
             match self.peek() {
                 None        => return Err(self.err("unterminated string")),
@@ -140,33 +161,45 @@ impl<'a> Parser<'a> {
                 Some(b'\\') => {
                     self.pos += 1;
                     match self.peek() {
-                        Some(b'"')  => { s.push('"');   self.pos += 1; }
-                        Some(b'\\') => { s.push('\\');  self.pos += 1; }
-                        Some(b'/')  => { s.push('/');   self.pos += 1; }
-                        Some(b'n')  => { s.push('\n');  self.pos += 1; }
-                        Some(b'r')  => { s.push('\r');  self.pos += 1; }
-                        Some(b't')  => { s.push('\t');  self.pos += 1; }
-                        Some(b'b')  => { s.push('\x08'); self.pos += 1; }
-                        Some(b'f')  => { s.push('\x0C'); self.pos += 1; }
+                        Some(b'"')  => { buf.push(b'"');  self.pos += 1; }
+                        Some(b'\\') => { buf.push(b'\\'); self.pos += 1; }
+                        Some(b'/')  => { buf.push(b'/');  self.pos += 1; }
+                        Some(b'n')  => { buf.push(b'\n'); self.pos += 1; }
+                        Some(b'r')  => { buf.push(b'\r'); self.pos += 1; }
+                        Some(b't')  => { buf.push(b'\t'); self.pos += 1; }
+                        Some(b'b')  => { buf.push(0x08);  self.pos += 1; }
+                        Some(b'f')  => { buf.push(0x0C);  self.pos += 1; }
                         Some(b'u')  => {
                             self.pos += 1;
-                            if self.pos + 4 > self.src.len() {
-                                return Err(self.err("truncated \\u escape"));
-                            }
-                            let hex = std::str::from_utf8(&self.src[self.pos..self.pos+4])
-                                .map_err(|_| self.err("invalid \\u escape"))?;
-                            let cp = u32::from_str_radix(hex, 16)
-                                .map_err(|_| self.err("invalid \\u codepoint"))?;
-                            if let Some(ch) = char::from_u32(cp) { s.push(ch); }
-                            self.pos += 4;
+                            let cp = self.parse_hex4()?;
+                            // A character outside the BMP is escaped as a
+                            // surrogate pair; decoding the halves separately
+                            // yields two unpaired surrogates, which are not
+                            // characters, so the whole escape would be dropped.
+                            let cp = if (0xD800..0xDC00).contains(&cp)
+                                && self.src[self.pos..].starts_with(b"\\u")
+                            {
+                                let here = self.pos;
+                                self.pos += 2;
+                                let low = self.parse_hex4()?;
+                                if (0xDC00..0xE000).contains(&low) {
+                                    0x1_0000 + ((cp - 0xD800) << 10) + (low - 0xDC00)
+                                } else {
+                                    self.pos = here; // not a pair after all
+                                    cp
+                                }
+                            } else {
+                                cp
+                            };
+                            if let Some(ch) = char::from_u32(cp) { push_char(&mut buf, ch); }
                         }
-                        _ => s.push('\\'),
+                        _ => buf.push(b'\\'),
                     }
                 }
-                Some(b) => { s.push(b as char); self.pos += 1; }
+                Some(b) => { buf.push(b); self.pos += 1; }
             }
         }
-        Ok(s)
+        String::from_utf8(buf).map_err(|_| self.err("invalid UTF-8 in string"))
     }
 
     fn parse_number(&mut self) -> Result<Jv> {

--- a/crates/wbvector/src/topojson/mod.rs
+++ b/crates/wbvector/src/topojson/mod.rs
@@ -198,9 +198,30 @@ impl<'a> Parser<'a> {
         }
     }
 
+    /// Reads the four hex digits of a `\u` escape, leaving `pos` after them.
+    fn parse_hex4(&mut self) -> Result<u32> {
+        if self.pos + 4 > self.src.len() {
+            return Err(self.err("truncated unicode escape"));
+        }
+        let hex = std::str::from_utf8(&self.src[self.pos..self.pos + 4])
+            .map_err(|_| self.err("invalid unicode escape"))?;
+        let cp = u32::from_str_radix(hex, 16).map_err(|_| self.err("invalid unicode codepoint"))?;
+        self.pos += 4;
+        Ok(cp)
+    }
+
+    /// Parses a JSON string. The source is UTF-8, so unescaped bytes are copied
+    /// through verbatim and decoded once at the end: pushing each byte as a
+    /// `char` would read it as a Latin-1 code point and re-encode it, turning
+    /// every non-ASCII character into mojibake ("Céréales" -> "CÃ©rÃ©ales") in
+    /// every property value and key a tool reads (opengeos/GeoLibre#1977).
     fn parse_string(&mut self) -> Result<String> {
         self.eat(b'"')?;
-        let mut s = String::new();
+        let mut buf: Vec<u8> = Vec::new();
+        let mut push_char = |buf: &mut Vec<u8>, ch: char| {
+            let mut utf8 = [0u8; 4];
+            buf.extend_from_slice(ch.encode_utf8(&mut utf8).as_bytes());
+        };
         loop {
             match self.peek() {
                 None => return Err(self.err("unterminated string")),
@@ -212,61 +233,73 @@ impl<'a> Parser<'a> {
                     self.pos += 1;
                     match self.peek() {
                         Some(b'"') => {
-                            s.push('"');
+                            buf.push(b'"');
                             self.pos += 1;
                         }
                         Some(b'\\') => {
-                            s.push('\\');
+                            buf.push(b'\\');
                             self.pos += 1;
                         }
                         Some(b'/') => {
-                            s.push('/');
+                            buf.push(b'/');
                             self.pos += 1;
                         }
                         Some(b'n') => {
-                            s.push('\n');
+                            buf.push(b'\n');
                             self.pos += 1;
                         }
                         Some(b'r') => {
-                            s.push('\r');
+                            buf.push(b'\r');
                             self.pos += 1;
                         }
                         Some(b't') => {
-                            s.push('\t');
+                            buf.push(b'\t');
                             self.pos += 1;
                         }
                         Some(b'b') => {
-                            s.push('\x08');
+                            buf.push(0x08);
                             self.pos += 1;
                         }
                         Some(b'f') => {
-                            s.push('\x0C');
+                            buf.push(0x0C);
                             self.pos += 1;
                         }
                         Some(b'u') => {
                             self.pos += 1;
-                            if self.pos + 4 > self.src.len() {
-                                return Err(self.err("truncated unicode escape"));
-                            }
-                            let hex = std::str::from_utf8(&self.src[self.pos..self.pos + 4])
-                                .map_err(|_| self.err("invalid unicode escape"))?;
-                            let cp = u32::from_str_radix(hex, 16)
-                                .map_err(|_| self.err("invalid unicode codepoint"))?;
+                            let cp = self.parse_hex4()?;
+                            // A character outside the BMP is escaped as a
+                            // surrogate pair; decoding the halves separately
+                            // yields two unpaired surrogates, which are not
+                            // characters, so the whole escape would be dropped.
+                            let cp = if (0xD800..0xDC00).contains(&cp)
+                                && self.src[self.pos..].starts_with(b"\\u")
+                            {
+                                let here = self.pos;
+                                self.pos += 2;
+                                let low = self.parse_hex4()?;
+                                if (0xDC00..0xE000).contains(&low) {
+                                    0x1_0000 + ((cp - 0xD800) << 10) + (low - 0xDC00)
+                                } else {
+                                    self.pos = here; // not a pair after all
+                                    cp
+                                }
+                            } else {
+                                cp
+                            };
                             if let Some(ch) = char::from_u32(cp) {
-                                s.push(ch);
+                                push_char(&mut buf, ch);
                             }
-                            self.pos += 4;
                         }
-                        _ => s.push('\\'),
+                        _ => buf.push(b'\\'),
                     }
                 }
                 Some(b) => {
-                    s.push(b as char);
+                    buf.push(b);
                     self.pos += 1;
                 }
             }
         }
-        Ok(s)
+        String::from_utf8(buf).map_err(|_| self.err("invalid UTF-8 in string"))
     }
 
     fn parse_number(&mut self) -> Result<Jv> {


### PR DESCRIPTION
## Summary

Both hand-written JSON string parsers pushed each unescaped source byte with `s.push(b as char)`. That reads the byte as a **Latin-1 code point** and re-encodes it as UTF-8, so every non-ASCII character in every property value and key comes back doubly encoded, and the mangling compounds each time a layer passes through a tool:

```
$ geolibre dissolve --input=in.geojson --dissolve_field=cls   # in.geojson: {"cls": "Céréales"}
{"cls":"CÃ©rÃ©ales"}
```

The source is UTF-8, so unescaped bytes are now copied through verbatim and the whole string is decoded once at the end.

While here: pair up surrogate escapes. `😀` was decoded half at a time, and `char::from_u32` rejects an unpaired surrogate, so the character was silently dropped — and escaping non-ASCII that way is exactly what a JSON writer in ASCII mode emits (`json.dump(..., ensure_ascii=True)` is Python's default).

Found while verifying opengeos/GeoLibre#1977, whose reporter's layer carries French land-use labels.

## Verification

`cargo test -p wbvector` cannot run in this tree — its test build fails on `include_str!` fixtures that are not vendored (`tests/fixtures/topojson_io/*.topojson`), which is pre-existing and why CI scopes `cargo test` to `wbgeotiff` and `whitebox-wasm`. Verified through the CLI instead, on a build carrying this and #20:

```
$ whitebox dissolve --input=utf8-test.geojson --dissolve_field=cls --output=out.geojson
features: 2
{'cls': 'Céréales'} MultiPolygon
{'cls': 'Viticulture'} Polygon
```

Before this change the same run wrote `CÃ©rÃ©ales`.